### PR TITLE
ListGroupRights proper localization

### DIFF
--- a/Tilesheets.php
+++ b/Tilesheets.php
@@ -64,6 +64,9 @@ $wgHooks['EditPage::showEditForm:initial'][] = 'TilesheetsHooks::OutputWarnings'
 $wgHooks['OreDictOutput'][] = 'TilesheetsHooks::OreDictOutput';
 $wgHooks['LoadExtensionSchemaUpdates'][] = 'TilesheetsHooks::SchemaUpdate';
 
+$wgAvailableRights[] = 'edittilesheets';
+$wgAvailableRights[] = 'importtilesheets';
+
 $paths = [
 	'localBasePath' => __DIR__,
 	'remoteExtPath' => 'Tilesheets',

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -68,4 +68,8 @@
 	"logentry-tilesheet-deletesheet": "$1 deleted the $4 tilesheet.",
 	"logentry-tilesheet-editsheet": "$1 edited the $6 tilesheet. Changes: $4.",
 	"logentry-tilesheet-edittile": "$1 edited tile #$6 ($7) positioned at ($9, $10) on the $8 tilesheet. Changes: $4."
+	"action-edittilesheets": "edit tiles",
+	"right-edittilesheets": "Edit tile data for the Tilesheets extension",
+	"action-importtilesheets": "upload new and update tilesheets",
+	"right-importtilesheets": "Upload new and update existing tilesheets for the Tilesheet extension"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -67,7 +67,7 @@
 	"logentry-tilesheet-createsheet": "$1 created a new sheet for $4.",
 	"logentry-tilesheet-deletesheet": "$1 deleted the $4 tilesheet.",
 	"logentry-tilesheet-editsheet": "$1 edited the $6 tilesheet. Changes: $4.",
-	"logentry-tilesheet-edittile": "$1 edited tile #$6 ($7) positioned at ($9, $10) on the $8 tilesheet. Changes: $4."
+	"logentry-tilesheet-edittile": "$1 edited tile #$6 ($7) positioned at ($9, $10) on the $8 tilesheet. Changes: $4.",
 	"action-edittilesheets": "edit tiles",
 	"right-edittilesheets": "Edit tile data for the Tilesheets extension",
 	"action-importtilesheets": "upload new and update tilesheets",


### PR DESCRIPTION
I added action-* and right-* entries to the base language JSON file. I read that this is how you do it on [a MediaWiki manual](https://www.mediawiki.org/wiki/Manual:User_rights#Adding_new_rights), but if that's outdated or not correct for this extension for some reason (I couldn't find $wgAvailableRights anywhere in the code, which makes me think we have to do it differently), then someone should definitely let me know.